### PR TITLE
fix: correctly unwrap message in s3 pusher

### DIFF
--- a/rust/agents/processor/src/push.rs
+++ b/rust/agents/processor/src/push.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use ethers::utils::keccak256;
 use rusoto_core::{credential::EnvironmentProvider, HttpClient, Region, RusotoError};
 use rusoto_s3::{GetObjectError, GetObjectRequest, PutObjectRequest, S3Client, S3};
 
@@ -7,7 +8,7 @@ use color_eyre::eyre::{bail, eyre, Result};
 
 use nomad_base::NomadDB;
 
-use nomad_core::{accumulator::merkle::Proof, Encode};
+use nomad_core::accumulator::merkle::Proof;
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{debug, info, info_span, instrument::Instrumented, Instrument};
 
@@ -122,11 +123,10 @@ impl Pusher {
                         let message = self
                             .db
                             .message_by_leaf_index(index)?
+                            .map(|message| message.message)
                             .ok_or_else(|| eyre!("Missing message for known proof"))?;
-                        let proven = ProvenMessage {
-                            proof,
-                            message: message.to_vec(),
-                        };
+                        debug_assert_eq!(keccak256(&message), *proof.leaf.as_fixed_bytes());
+                        let proven = ProvenMessage { proof, message };
                         // upload if not already present
                         if !self.already_uploaded(&proven).await? {
                             self.upload_proof(&proven).await?;


### PR DESCRIPTION
My initial implementation incorrectly serialized the raw committed message for use in the s3 proof. instead of the payload of the nomad message

@yourbuddyconner this will require all s3 proofs to be deleted, but should not require agent state to be nuked 

This has been causing the `!prove` processing UI bugs cc @ErinHales 