### PR TITLE
feature: watcher handles improper updates (without state proofs)

### DIFF
--- a/rust/agents/processor/src/processor.rs
+++ b/rust/agents/processor/src/processor.rs
@@ -216,10 +216,10 @@ impl Replica {
         };
 
         if proof.leaf != message.to_leaf() {
-            bail!(ProcessorError::ConflictingUpdateAttemptError {
+            bail!(ProcessorError::ProverConflictError {
                 index: message.leaf_index,
                 calculated_leaf: message.to_leaf(),
-                prover_leaf: proof.leaf,
+                proof_leaf: proof.leaf,
             });
         }
 

--- a/rust/agents/watcher/src/watcher.rs
+++ b/rust/agents/watcher/src/watcher.rs
@@ -585,6 +585,10 @@ impl NomadAgent for Watcher {
                 improper_res = improper_update_watch_task => {
                     let state = improper_res??;
                     if state == State::Failed {
+                        tracing::error!(
+                            "Improper update detected! Notifying all contracts and unenrolling replicas!",
+                        );
+
                         self.handle_improper_update_failure()
                             .await
                             .iter()

--- a/rust/agents/watcher/src/watcher.rs
+++ b/rust/agents/watcher/src/watcher.rs
@@ -579,6 +579,8 @@ impl NomadAgent for Watcher {
                         "#
                         )
                     }
+
+                    self.shutdown().await;
                 },
                 improper_res = improper_update_watch_task => {
                     let state = improper_res??;
@@ -596,6 +598,8 @@ impl NomadAgent for Watcher {
                         "#
                         )
                     }
+
+                    self.shutdown().await;
                 }
             }
 

--- a/rust/chains/nomad-ethereum/src/home.rs
+++ b/rust/chains/nomad-ethereum/src/home.rs
@@ -217,8 +217,9 @@ where
     async fn state(&self) -> Result<State, ChainCommunicationError> {
         let state = self.contract.state().call().await?;
         match state {
-            0 => Ok(State::Waiting),
-            1 => Ok(State::Failed),
+            0 => Ok(State::Uninitialized),
+            1 => Ok(State::Active),
+            2 => Ok(State::Failed),
             _ => unreachable!(),
         }
     }

--- a/rust/chains/nomad-ethereum/src/replica.rs
+++ b/rust/chains/nomad-ethereum/src/replica.rs
@@ -180,8 +180,9 @@ where
     async fn state(&self) -> Result<State, ChainCommunicationError> {
         let state = self.contract.state().call().await?;
         match state {
-            0 => Ok(State::Waiting),
-            1 => Ok(State::Failed),
+            0 => Ok(State::Uninitialized),
+            1 => Ok(State::Active),
+            2 => Ok(State::Failed),
             _ => unreachable!(),
         }
     }

--- a/rust/nomad-base/src/error.rs
+++ b/rust/nomad-base/src/error.rs
@@ -32,7 +32,7 @@ pub enum AgentError {
 /// Error that happened in Updater
 #[derive(Debug, thiserror::Error)]
 pub enum UpdaterError {
-    /// Error on conflict
+    /// Update producer attampted to store conflicting updates
     #[error("Updater attempted to store conflicting signed update. Existing: {existing:?}. New conflicting: {conflicting:?}.")]
     ProducerConflictError {
         /// Existing signed update
@@ -45,14 +45,14 @@ pub enum UpdaterError {
 /// Error that happened in Processor
 #[derive(Debug, thiserror::Error)]
 pub enum ProcessorError {
-    /// UpdaterConflictError
-    #[error("Updater attempted to store conflicting signed update.  Index: {index:?}. Calculated: {calculated_leaf:?}. Prover: {prover_leaf:?}.")]
-    ConflictingUpdateAttemptError {
+    /// Processor stored leaf conflicts with the message for the same index
+    #[error("Processor stored leaf and message hash are not equal for leaf index: {index:?}. Calculated: {calculated_leaf:?}. Prover: {proof_leaf:?}.")]
+    ProverConflictError {
         /// Leaf index
         index: u32,
         /// Conflicting message leaf
         calculated_leaf: H256,
         /// Prover leaf
-        prover_leaf: H256,
+        proof_leaf: H256,
     },
 }

--- a/rust/nomad-core/src/traits/mod.rs
+++ b/rust/nomad-core/src/traits/mod.rs
@@ -22,7 +22,7 @@ pub use replica::*;
 pub use xapp::*;
 
 /// Contract states
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum State {
     /// Contract is active
     Waiting,

--- a/rust/nomad-core/src/traits/mod.rs
+++ b/rust/nomad-core/src/traits/mod.rs
@@ -24,8 +24,10 @@ pub use xapp::*;
 /// Contract states
 #[derive(Debug, PartialEq, Eq)]
 pub enum State {
+    /// Contract uninitialized
+    Uninitialized,
     /// Contract is active
-    Waiting,
+    Active,
     /// Contract has failed
     Failed,
 }


### PR DESCRIPTION
- adds functionality for checking home for failed state and unenrolling replicas if failed
- refactors watcher to stop using `tokio::oneshot` for simplification and uses `select!` macro instead of `select_all` so we can select across futures of different return types

Closes #11 