### PR TITLE
feat: changes to publish core-contracts and xapp-contracts

### DIFF
--- a/solidity/nomad-core/package-lock.json
+++ b/solidity/nomad-core/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@nomad-xyz/nomad-core-sol",
+  "name": "@nomad-xyz/core-contracts",
   "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nomad-xyz/nomad-core-sol",
+      "name": "@nomad-xyz/core-contracts",
       "version": "1.1.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/solidity/nomad-core/package.json
+++ b/solidity/nomad-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomad-xyz/nomad-core-sol",
+  "name": "@nomad-xyz/core-contracts",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.2",
@@ -20,7 +20,7 @@
     "ts-node": "^10.1.0",
     "typechain": "^5.0.0"
   },
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Nomad contracts",
   "main": "",
   "directories": {

--- a/solidity/nomad-xapps/contracts/Router.sol
+++ b/solidity/nomad-xapps/contracts/Router.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.6.11;
 // ============ Internal Imports ============
 import {XAppConnectionClient} from "./XAppConnectionClient.sol";
 // ============ External Imports ============
-import {IMessageRecipient} from "@nomad-xyz/nomad-core-sol/interfaces/IMessageRecipient.sol";
+import {IMessageRecipient} from "@nomad-xyz/core-contracts/interfaces/IMessageRecipient.sol";
 
 abstract contract Router is XAppConnectionClient, IMessageRecipient {
     // ============ Mutable Storage ============

--- a/solidity/nomad-xapps/contracts/XAppConnectionClient.sol
+++ b/solidity/nomad-xapps/contracts/XAppConnectionClient.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.6.11;
 
 // ============ External Imports ============
-import {Home} from "@nomad-xyz/nomad-core-sol/contracts/Home.sol";
-import {XAppConnectionManager} from "@nomad-xyz/nomad-core-sol/contracts/XAppConnectionManager.sol";
+import {Home} from "@nomad-xyz/core-contracts/contracts/Home.sol";
+import {XAppConnectionManager} from "@nomad-xyz/core-contracts/contracts/XAppConnectionManager.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 abstract contract XAppConnectionClient is OwnableUpgradeable {

--- a/solidity/nomad-xapps/contracts/bridge/BridgeRouter.sol
+++ b/solidity/nomad-xapps/contracts/bridge/BridgeRouter.sol
@@ -8,8 +8,8 @@ import {XAppConnectionClient} from "../XAppConnectionClient.sol";
 import {BridgeMessage} from "./BridgeMessage.sol";
 import {IBridgeToken} from "../../interfaces/bridge/IBridgeToken.sol";
 // ============ External Imports ============
-import {Home} from "@nomad-xyz/nomad-core-sol/contracts/Home.sol";
-import {Version0} from "@nomad-xyz/nomad-core-sol/contracts/Version0.sol";
+import {Home} from "@nomad-xyz/core-contracts/contracts/Home.sol";
+import {Version0} from "@nomad-xyz/core-contracts/contracts/Version0.sol";
 import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";

--- a/solidity/nomad-xapps/contracts/bridge/BridgeToken.sol
+++ b/solidity/nomad-xapps/contracts/bridge/BridgeToken.sol
@@ -6,8 +6,8 @@ import {IBridgeToken} from "../../interfaces/bridge/IBridgeToken.sol";
 import {ERC20} from "./vendored/OZERC20.sol";
 import {BridgeMessage} from "./BridgeMessage.sol";
 // ============ External Imports ============
-import {Version0} from "@nomad-xyz/nomad-core-sol/contracts/Version0.sol";
-import {TypeCasts} from "@nomad-xyz/nomad-core-sol/contracts/XAppConnectionManager.sol";
+import {Version0} from "@nomad-xyz/core-contracts/contracts/Version0.sol";
+import {TypeCasts} from "@nomad-xyz/core-contracts/contracts/XAppConnectionManager.sol";
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 contract BridgeToken is Version0, IBridgeToken, OwnableUpgradeable, ERC20 {

--- a/solidity/nomad-xapps/contracts/bridge/ETHHelper.sol
+++ b/solidity/nomad-xapps/contracts/bridge/ETHHelper.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.6.11;
 import {BridgeRouter} from "./BridgeRouter.sol";
 import {IWeth} from "../../interfaces/bridge/IWeth.sol";
 // ============ External Imports ============
-import {TypeCasts} from "@nomad-xyz/nomad-core-sol/contracts/XAppConnectionManager.sol";
+import {TypeCasts} from "@nomad-xyz/core-contracts/contracts/XAppConnectionManager.sol";
 
 contract ETHHelper {
     // ============ Immutables ============

--- a/solidity/nomad-xapps/contracts/bridge/TokenRegistry.sol
+++ b/solidity/nomad-xapps/contracts/bridge/TokenRegistry.sol
@@ -5,8 +5,8 @@ pragma solidity >=0.6.11;
 import {BridgeMessage} from "./BridgeMessage.sol";
 import {XAppConnectionClient} from "../XAppConnectionClient.sol";
 import {Encoding} from "./Encoding.sol";
-import {TypeCasts} from "@nomad-xyz/nomad-core-sol/contracts/XAppConnectionManager.sol";
-import {UpgradeBeaconProxy} from "@nomad-xyz/nomad-core-sol/contracts/upgrade/UpgradeBeaconProxy.sol";
+import {TypeCasts} from "@nomad-xyz/core-contracts/contracts/XAppConnectionManager.sol";
+import {UpgradeBeaconProxy} from "@nomad-xyz/core-contracts/contracts/upgrade/UpgradeBeaconProxy.sol";
 // ============ Interfaces ============
 import {ITokenRegistry} from "../../interfaces/bridge/ITokenRegistry.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/solidity/nomad-xapps/contracts/bridge/test/MockCore.sol
+++ b/solidity/nomad-xapps/contracts/bridge/test/MockCore.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.11;
 
-import {MerkleTreeManager} from "@nomad-xyz/nomad-core-sol/contracts/Merkle.sol";
-import {QueueManager} from "@nomad-xyz/nomad-core-sol/contracts/Queue.sol";
+import {MerkleTreeManager} from "@nomad-xyz/core-contracts/contracts/Merkle.sol";
+import {QueueManager} from "@nomad-xyz/core-contracts/contracts/Queue.sol";
 
-import {Message} from "@nomad-xyz/nomad-core-sol/libs/Message.sol";
-import {MerkleLib} from "@nomad-xyz/nomad-core-sol/libs/Merkle.sol";
-import {QueueLib} from "@nomad-xyz/nomad-core-sol/libs/Queue.sol";
+import {Message} from "@nomad-xyz/core-contracts/libs/Message.sol";
+import {MerkleLib} from "@nomad-xyz/core-contracts/libs/Merkle.sol";
+import {QueueLib} from "@nomad-xyz/core-contracts/libs/Queue.sol";
 
 // We reproduce a significant amount of logic from `Home` to ensure that
 // calling dispatch here is AT LEAST AS EXPENSIVE as calling it on home

--- a/solidity/nomad-xapps/package-lock.json
+++ b/solidity/nomad-xapps/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@nomad-xyz/nomad-xapps-sol",
-  "version": "1.1.0",
+  "name": "@nomad-xyz/xapp-contracts",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nomad-xyz/nomad-xapps-sol",
-      "version": "1.1.0",
+      "name": "@nomad-xyz/xapp-contracts",
+      "version": "1.0.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@nomad-xyz/nomad-core-sol": "file:../nomad-core",
+        "@nomad-xyz/core-contracts": "v1.0.0",
         "@openzeppelin/contracts": "~3.4.2",
         "@openzeppelin/contracts-upgradeable": "~3.4.2",
         "@summa-tx/memview-sol": "^2.0.0"
@@ -38,8 +38,9 @@
       }
     },
     "../nomad-core": {
-      "name": "@nomad-xyz/nomad-core-sol",
-      "version": "0.0.1",
+      "name": "@nomad-xyz/core-contracts",
+      "version": "1.0.0",
+      "extraneous": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^3.4.2",
@@ -1421,9 +1422,17 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@nomad-xyz/nomad-core-sol": {
-      "resolved": "../nomad-core",
-      "link": true
+    "node_modules/@nomad-xyz/core-contracts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nomad-xyz/core-contracts/-/core-contracts-1.0.0.tgz",
+      "integrity": "sha512-hrLE+vUnNGLCQQkpoxZ7S0J51g0zK+U7N/cznqJ0rucpy+RXPmhCDLISGJdiMrU3/0GWtCRVO+Du58xqiLTqUg==",
+      "dependencies": {
+        "@openzeppelin/contracts": "^3.4.2",
+        "@openzeppelin/contracts-upgradeable": "~3.4.2",
+        "@summa-tx/memview-sol": "^2.0.0",
+        "dotenv": "^10.0.0",
+        "ts-generator": "^0.1.1"
+      }
     },
     "node_modules/@nomiclabs/hardhat-ethers": {
       "version": "2.0.3",
@@ -1981,7 +1990,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1989,8 +1997,7 @@
     "node_modules/@types/node": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
-      "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==",
-      "dev": true
+      "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -2014,8 +2021,7 @@
     "node_modules/@types/prettier": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
-      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
-      "dev": true
+      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -2027,7 +2033,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
       "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2486,8 +2491,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base-x": {
       "version": "3.0.9",
@@ -2645,7 +2649,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3276,8 +3279,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -3808,7 +3810,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -5268,8 +5269,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -15689,7 +15689,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -16418,7 +16417,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -16427,8 +16425,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -17747,7 +17744,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17758,8 +17754,7 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/minipass": {
       "version": "2.9.0",
@@ -17784,7 +17779,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -18423,7 +18417,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -18821,7 +18814,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18844,8 +18836,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -18964,7 +18955,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -19567,7 +19557,6 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "dev": true,
       "dependencies": {
         "path-parse": "^1.0.6"
       },
@@ -21558,7 +21547,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ts-generator/-/ts-generator-0.1.1.tgz",
       "integrity": "sha512-N+ahhZxTLYu1HNTQetwWcx3so8hcYbkKBHTr4b4/YgObFTIKkOSSsaa+nal12w8mfrJAyzJfETXawbNjSfP2gQ==",
-      "dev": true,
       "dependencies": {
         "@types/mkdirp": "^0.5.2",
         "@types/prettier": "^2.1.1",
@@ -21578,7 +21566,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -21590,7 +21577,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -21604,7 +21590,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -21612,14 +21597,12 @@
     "node_modules/ts-generator/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/ts-generator/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -21628,7 +21611,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -21637,7 +21619,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -21648,8 +21629,7 @@
     "node_modules/ts-generator/node_modules/ts-essentials": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
-      "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==",
-      "dev": true
+      "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ=="
     },
     "node_modules/ts-node": {
       "version": "10.4.0",
@@ -23051,8 +23031,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write": {
       "version": "1.0.3",
@@ -24290,32 +24269,16 @@
         "fastq": "^1.6.0"
       }
     },
-    "@nomad-xyz/nomad-core-sol": {
-      "version": "file:../nomad-core",
+    "@nomad-xyz/core-contracts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nomad-xyz/core-contracts/-/core-contracts-1.0.0.tgz",
+      "integrity": "sha512-hrLE+vUnNGLCQQkpoxZ7S0J51g0zK+U7N/cznqJ0rucpy+RXPmhCDLISGJdiMrU3/0GWtCRVO+Du58xqiLTqUg==",
       "requires": {
-        "@nomiclabs/hardhat-ethers": "^2.0.1",
-        "@nomiclabs/hardhat-etherscan": "^2.1.2",
-        "@nomiclabs/hardhat-waffle": "^2.0.1",
         "@openzeppelin/contracts": "^3.4.2",
         "@openzeppelin/contracts-upgradeable": "~3.4.2",
         "@summa-tx/memview-sol": "^2.0.0",
-        "@typechain/ethers-v5": "^7.0.0",
-        "@typechain/hardhat": "^2.0.1",
-        "chai": "^4.3.0",
         "dotenv": "^10.0.0",
-        "eslint": "^7.20.0",
-        "ethereum-waffle": "^3.2.2",
-        "ethers": "^5.4.4",
-        "hardhat": "^2.6.0",
-        "hardhat-gas-reporter": "^1.0.4",
-        "prettier": "^2.2.1",
-        "prettier-plugin-solidity": "^1.0.0-beta.5",
-        "solhint": "^3.3.2",
-        "solhint-plugin-prettier": "^0.0.5",
-        "solidity-coverage": "^0.7.14",
-        "ts-generator": "^0.1.1",
-        "ts-node": "^10.1.0",
-        "typechain": "^5.0.0"
+        "ts-generator": "^0.1.1"
       }
     },
     "@nomiclabs/hardhat-ethers": {
@@ -24827,7 +24790,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -24835,8 +24797,7 @@
     "@types/node": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.2.tgz",
-      "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA==",
-      "dev": true
+      "integrity": "sha512-JepeIUPFDARgIs0zD/SKPgFsJEAF0X5/qO80llx59gOxFTboS9Amv3S+QfB7lqBId5sFXJ99BN0J6zFRvL9dDA=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -24860,8 +24821,7 @@
     "@types/prettier": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
-      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
-      "dev": true
+      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -24873,7 +24833,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
       "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -25241,8 +25200,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base-x": {
       "version": "3.0.9",
@@ -25375,7 +25333,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -25905,8 +25862,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -26346,8 +26302,7 @@
     "dotenv": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "dev": true
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -27574,8 +27529,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -35551,7 +35505,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -36124,7 +36077,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -36133,8 +36085,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -37151,7 +37102,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -37159,8 +37109,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -37185,7 +37134,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -37694,7 +37642,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -38000,8 +37947,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -38018,8 +37964,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -38106,8 +38051,7 @@
     "prettier": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "dev": true
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -38563,7 +38507,6 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -40146,7 +40089,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ts-generator/-/ts-generator-0.1.1.tgz",
       "integrity": "sha512-N+ahhZxTLYu1HNTQetwWcx3so8hcYbkKBHTr4b4/YgObFTIKkOSSsaa+nal12w8mfrJAyzJfETXawbNjSfP2gQ==",
-      "dev": true,
       "requires": {
         "@types/mkdirp": "^0.5.2",
         "@types/prettier": "^2.1.1",
@@ -40163,7 +40105,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -40172,7 +40113,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -40183,7 +40123,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -40191,26 +40130,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -40218,8 +40153,7 @@
         "ts-essentials": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
-          "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==",
-          "dev": true
+          "integrity": "sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ=="
         }
       }
     },
@@ -41407,8 +41341,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/solidity/nomad-xapps/package.json
+++ b/solidity/nomad-xapps/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nomad-xyz/nomad-xapps-sol",
+  "name": "@nomad-xyz/xapp-contracts",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-etherscan": "^2.1.2",
@@ -22,9 +22,9 @@
     "typechain": "^5.0.0",
     "typescript": "^4.3.5"
   },
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "A bridge using nomad",
-  "main": " ",
+  "main": "",
   "scripts": {
     "prettier": "prettier --write './contracts'",
     "compile": "hardhat compile && hardhat typechain && npm run prettier",
@@ -43,7 +43,7 @@
   "author": "James Prestwich",
   "license": "MIT OR Apache-2.0",
   "dependencies": {
-    "@nomad-xyz/nomad-core-sol": "file:../nomad-core",
+    "@nomad-xyz/core-contracts": "v1.0.0",
     "@openzeppelin/contracts": "~3.4.2",
     "@openzeppelin/contracts-upgradeable": "~3.4.2",
     "@summa-tx/memview-sol": "^2.0.0"

--- a/tools/local-environment/package-lock.json
+++ b/tools/local-environment/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@ethersproject/experimental": "^5.5.0",
         "@nomad-xyz/contract-interfaces": "file:/../../typescript/typechain/dist",
-        "@nomad-xyz/contracts": "file:/../../solidity/nomad-core",
         "@nomad-xyz/deploy": "file:/../../typescript/nomad-deploy/dist",
         "@nomad-xyz/sdk": "file:/../../typescript/nomad-sdk/dist",
         "@nomad-xyz/test": "file:/../../typescript/nomad-tests",
@@ -31,8 +30,9 @@
       }
     },
     "../../solidity/nomad-core": {
-      "name": "@nomad-xyz/nomad-core-sol",
-      "version": "1.1.0",
+      "name": "@nomad-xyz/core-contracts",
+      "version": "1.0.0",
+      "extraneous": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^3.4.2",
@@ -65,14 +65,11 @@
     "../../typescript/nomad-deploy/dist": {},
     "../../typescript/nomad-sdk/dist": {
       "name": "@nomad-xyz/sdk",
-      "version": "1.2.1",
-      "license": "Apache-2.0 OR MIT",
+      "version": "1.2.3",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@gnosis.pm/safe-core-sdk": "^1.3.0",
-        "@gnosis.pm/safe-ethers-adapters": "0.1.0-alpha.7",
         "@nomad-xyz/contract-interfaces": "1.1.1",
-        "ethers": "^5.4.6",
-        "web3": "^1.6.1"
+        "ethers": "^5.4.6"
       },
       "devDependencies": {
         "@types/node": "^16.9.1",
@@ -943,10 +940,6 @@
     },
     "node_modules/@nomad-xyz/contract-interfaces": {
       "resolved": "../../typescript/typechain/dist",
-      "link": true
-    },
-    "node_modules/@nomad-xyz/contracts": {
-      "resolved": "../../solidity/nomad-core",
       "link": true
     },
     "node_modules/@nomad-xyz/deploy": {
@@ -5195,42 +5188,12 @@
         "typescript": "^4.4.3"
       }
     },
-    "@nomad-xyz/contracts": {
-      "version": "file:../../solidity/nomad-core",
-      "requires": {
-        "@nomiclabs/hardhat-ethers": "^2.0.1",
-        "@nomiclabs/hardhat-etherscan": "^2.1.2",
-        "@nomiclabs/hardhat-waffle": "^2.0.1",
-        "@openzeppelin/contracts": "^3.4.2",
-        "@openzeppelin/contracts-upgradeable": "~3.4.2",
-        "@summa-tx/memview-sol": "^2.0.0",
-        "@typechain/ethers-v5": "^7.0.0",
-        "@typechain/hardhat": "^2.0.1",
-        "chai": "^4.3.0",
-        "dotenv": "^10.0.0",
-        "eslint": "^7.20.0",
-        "ethereum-waffle": "^3.2.2",
-        "ethers": "^5.4.4",
-        "hardhat": "^2.6.0",
-        "hardhat-gas-reporter": "^1.0.4",
-        "prettier": "^2.2.1",
-        "prettier-plugin-solidity": "^1.0.0-beta.5",
-        "solhint": "^3.3.2",
-        "solhint-plugin-prettier": "^0.0.5",
-        "solidity-coverage": "^0.7.14",
-        "ts-generator": "^0.1.1",
-        "ts-node": "^10.1.0",
-        "typechain": "^5.0.0"
-      }
-    },
     "@nomad-xyz/deploy": {
       "version": "file:../../typescript/nomad-deploy/dist"
     },
     "@nomad-xyz/sdk": {
       "version": "file:../../typescript/nomad-sdk/dist",
       "requires": {
-        "@gnosis.pm/safe-core-sdk": "^1.3.0",
-        "@gnosis.pm/safe-ethers-adapters": "0.1.0-alpha.7",
         "@nomad-xyz/contract-interfaces": "1.1.1",
         "@types/node": "^16.9.1",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
@@ -5241,8 +5204,7 @@
         "ethers": "^5.4.6",
         "fs": "0.0.1-security",
         "prettier": "^2.4.1",
-        "typescript": "^4.4.3",
-        "web3": "^1.6.1"
+        "typescript": "^4.4.3"
       }
     },
     "@nomad-xyz/test": {

--- a/tools/local-environment/package.json
+++ b/tools/local-environment/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@nomad-xyz/contract-interfaces": "file:/../../typescript/typechain/dist",
     "@ethersproject/experimental": "^5.5.0",
-    "@nomad-xyz/contracts": "file:/../../solidity/nomad-core",
     "@nomad-xyz/deploy": "file:/../../typescript/nomad-deploy/dist",
     "@nomad-xyz/sdk": "file:/../../typescript/nomad-sdk/dist",
     "@nomad-xyz/test": "file:/../../typescript/nomad-tests",


### PR DESCRIPTION
core-contracts (https://www.npmjs.com/package/@nomad-xyz/core-contracts)
xapp-contracts (https://www.npmjs.com/package/@nomad-xyz/xapp-contracts)

Gonna delete the nomad-xyz/contracts package since it’s redundant now