### PR TITLE
Remove unnecessary contracts dependency

### DIFF
--- a/tools/local-environment/package-lock.json
+++ b/tools/local-environment/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@ethersproject/experimental": "^5.5.0",
         "@nomad-xyz/contract-interfaces": "file:/../../typescript/typechain/dist",
-        "@nomad-xyz/contracts": "file:/../../solidity/nomad-core",
         "@nomad-xyz/deploy": "file:/../../typescript/nomad-deploy/dist",
         "@nomad-xyz/sdk": "file:/../../typescript/nomad-sdk/dist",
         "@nomad-xyz/test": "file:/../../typescript/nomad-tests",
@@ -33,6 +32,7 @@
     "../../solidity/nomad-core": {
       "name": "@nomad-xyz/nomad-core-sol",
       "version": "1.1.0",
+      "extraneous": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@openzeppelin/contracts": "^3.4.2",
@@ -65,14 +65,11 @@
     "../../typescript/nomad-deploy/dist": {},
     "../../typescript/nomad-sdk/dist": {
       "name": "@nomad-xyz/sdk",
-      "version": "1.2.1",
-      "license": "Apache-2.0 OR MIT",
+      "version": "1.2.3",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@gnosis.pm/safe-core-sdk": "^1.3.0",
-        "@gnosis.pm/safe-ethers-adapters": "0.1.0-alpha.7",
         "@nomad-xyz/contract-interfaces": "1.1.1",
-        "ethers": "^5.4.6",
-        "web3": "^1.6.1"
+        "ethers": "^5.4.6"
       },
       "devDependencies": {
         "@types/node": "^16.9.1",
@@ -943,10 +940,6 @@
     },
     "node_modules/@nomad-xyz/contract-interfaces": {
       "resolved": "../../typescript/typechain/dist",
-      "link": true
-    },
-    "node_modules/@nomad-xyz/contracts": {
-      "resolved": "../../solidity/nomad-core",
       "link": true
     },
     "node_modules/@nomad-xyz/deploy": {
@@ -5195,42 +5188,12 @@
         "typescript": "^4.4.3"
       }
     },
-    "@nomad-xyz/contracts": {
-      "version": "file:../../solidity/nomad-core",
-      "requires": {
-        "@nomiclabs/hardhat-ethers": "^2.0.1",
-        "@nomiclabs/hardhat-etherscan": "^2.1.2",
-        "@nomiclabs/hardhat-waffle": "^2.0.1",
-        "@openzeppelin/contracts": "^3.4.2",
-        "@openzeppelin/contracts-upgradeable": "~3.4.2",
-        "@summa-tx/memview-sol": "^2.0.0",
-        "@typechain/ethers-v5": "^7.0.0",
-        "@typechain/hardhat": "^2.0.1",
-        "chai": "^4.3.0",
-        "dotenv": "^10.0.0",
-        "eslint": "^7.20.0",
-        "ethereum-waffle": "^3.2.2",
-        "ethers": "^5.4.4",
-        "hardhat": "^2.6.0",
-        "hardhat-gas-reporter": "^1.0.4",
-        "prettier": "^2.2.1",
-        "prettier-plugin-solidity": "^1.0.0-beta.5",
-        "solhint": "^3.3.2",
-        "solhint-plugin-prettier": "^0.0.5",
-        "solidity-coverage": "^0.7.14",
-        "ts-generator": "^0.1.1",
-        "ts-node": "^10.1.0",
-        "typechain": "^5.0.0"
-      }
-    },
     "@nomad-xyz/deploy": {
       "version": "file:../../typescript/nomad-deploy/dist"
     },
     "@nomad-xyz/sdk": {
       "version": "file:../../typescript/nomad-sdk/dist",
       "requires": {
-        "@gnosis.pm/safe-core-sdk": "^1.3.0",
-        "@gnosis.pm/safe-ethers-adapters": "0.1.0-alpha.7",
         "@nomad-xyz/contract-interfaces": "1.1.1",
         "@types/node": "^16.9.1",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
@@ -5241,8 +5204,7 @@
         "ethers": "^5.4.6",
         "fs": "0.0.1-security",
         "prettier": "^2.4.1",
-        "typescript": "^4.4.3",
-        "web3": "^1.6.1"
+        "typescript": "^4.4.3"
       }
     },
     "@nomad-xyz/test": {

--- a/tools/local-environment/package.json
+++ b/tools/local-environment/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@nomad-xyz/contract-interfaces": "file:/../../typescript/typechain/dist",
     "@ethersproject/experimental": "^5.5.0",
-    "@nomad-xyz/contracts": "file:/../../solidity/nomad-core",
     "@nomad-xyz/deploy": "file:/../../typescript/nomad-deploy/dist",
     "@nomad-xyz/sdk": "file:/../../typescript/nomad-sdk/dist",
     "@nomad-xyz/test": "file:/../../typescript/nomad-tests",


### PR DESCRIPTION
This `@nomad-xyz/contracts` npm package has been deleted anyways and replaced with nomad-core-sol (https://www.npmjs.com/package/@nomad-xyz/nomad-core-sol). It wasn't being used here either.