### PR TITLE
fix: temporarily reduce block size from 2000->1000 for moonbeam

### DIFF
--- a/typescript/nomad-sdk/package-lock.json
+++ b/typescript/nomad-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nomad-xyz/sdk",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@gnosis.pm/safe-core-sdk": "^1.3.0",

--- a/typescript/nomad-sdk/src/nomad/domains/dev.ts
+++ b/typescript/nomad-sdk/src/nomad/domains/dev.ts
@@ -51,7 +51,7 @@ export const moonbasealpha: NomadDomain = {
   id: 5000,
   paginate: {
     from: 1555095,
-    blocks: 2000,
+    blocks: 1000,
   },
   home: '0x79F0267e3e4E457E13Ed79552D3606382bb0F66a',
   replicas: [

--- a/typescript/nomad-sdk/src/nomad/domains/mainnet.ts
+++ b/typescript/nomad-sdk/src/nomad/domains/mainnet.ts
@@ -26,7 +26,7 @@ export const moonbeam: NomadDomain = {
   id: 1650811245,
   paginate: {
     from: 171256,
-    blocks: 2000,
+    blocks: 1000,
   },
   home: '0x8F184D6Aa1977fd2F9d9024317D0ea5cF5815b6f',
   replicas: [

--- a/typescript/nomad-sdk/src/nomad/domains/staging.ts
+++ b/typescript/nomad-sdk/src/nomad/domains/staging.ts
@@ -51,7 +51,7 @@ export const moonbasealpha: NomadDomain = {
   id: 5000,
   paginate: {
     from: 1556676,
-    blocks: 2000,
+    blocks: 1000,
   },
   home: '0xeA5EE132A66c2cE09AEB8baDdabb26EcF33603AE',
   replicas: [


### PR DESCRIPTION
- reducing block size while bware figures out infra issues
- bumped package-lock which wasn't up to date