### PR TITLE
fix: temporarily reduce block range from 1000 -> 500 for moonbeam

### DIFF
--- a/typescript/nomad-sdk/src/nomad/domains/dev.ts
+++ b/typescript/nomad-sdk/src/nomad/domains/dev.ts
@@ -55,7 +55,7 @@ export const moonbasealpha: NomadDomain = {
   id: 5000,
   paginate: {
     from: 1555095,
-    blocks: 1000,
+    blocks: 500,
   },
   home: '0x79F0267e3e4E457E13Ed79552D3606382bb0F66a',
   replicas: [

--- a/typescript/nomad-sdk/src/nomad/domains/mainnet.ts
+++ b/typescript/nomad-sdk/src/nomad/domains/mainnet.ts
@@ -26,7 +26,7 @@ export const moonbeam: NomadDomain = {
   id: 1650811245,
   paginate: {
     from: 171256,
-    blocks: 1000,
+    blocks: 500,
   },
   home: '0x8F184D6Aa1977fd2F9d9024317D0ea5cF5815b6f',
   replicas: [

--- a/typescript/nomad-sdk/src/nomad/domains/staging.ts
+++ b/typescript/nomad-sdk/src/nomad/domains/staging.ts
@@ -51,7 +51,7 @@ export const moonbasealpha: NomadDomain = {
   id: 5000,
   paginate: {
     from: 1556676,
-    blocks: 1000,
+    blocks: 500,
   },
   home: '0xeA5EE132A66c2cE09AEB8baDdabb26EcF33603AE',
   replicas: [


### PR DESCRIPTION
Reducing again to 500 as a workaround for bware infra timeout issues