### PR TITLE
fix: make checkHome public

### DIFF
--- a/typescript/nomad-sdk/src/nomad/NomadContext.ts
+++ b/typescript/nomad-sdk/src/nomad/NomadContext.ts
@@ -259,7 +259,11 @@ export class NomadContext extends MultiProvider {
     return this._blacklist;
   }
 
-  private async checkHome(nameOrDomain: string | number): Promise<void> {
+  async checkHomes(networks: (string | number)[]): Promise<void> {
+    networks.forEach(async (n) => await this.checkHome(n))
+  }
+
+  async checkHome(nameOrDomain: string | number): Promise<void> {
     const domain = this.resolveDomain(nameOrDomain);
     const home = this.mustGetCore(domain).home;
     const state = await home.state();


### PR DESCRIPTION
Makes `checkHome` public
Adds `checkHomes` for convenience

Context: Would like to check on load for any failed homes, display a banner and filter out networks in failed state.  Currently, it's only checked when user tries to take action such as `send`, `sendNative` or `process`.