### PR TITLE
bug: false double update errors

### DIFF
--- a/typescript/nomad-sdk/package-lock.json
+++ b/typescript/nomad-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nomad-xyz/sdk",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@gnosis.pm/safe-core-sdk": "^1.3.0",

--- a/typescript/nomad-sdk/package.json
+++ b/typescript/nomad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Nomad SDK",
   "main": "index.js",
   "types": "index.d.ts",

--- a/typescript/nomad-sdk/src/nomad/messages/NomadMessage.ts
+++ b/typescript/nomad-sdk/src/nomad/messages/NomadMessage.ts
@@ -250,11 +250,15 @@ export class NomadMessage {
       UpdateArgs
     >(this.context, this.origin, this.home, updateFilter);
 
-    if (updateLogs.length === 1) {
-      // if event is returned, store it to the object
-      this.cache.homeUpdate = updateLogs[0];
-    } else if (updateLogs.length > 1) {
-      throw new Error('multiple home updates for same root');
+    if (updateLogs.length > 0) {
+      // check for distinct (fraudulent) updates
+      const validUpdates = updateLogs.every(u => u === updateLogs[0]);
+      if (validUpdates) {
+        // if event is returned and valid, store it to the object
+        this.cache.homeUpdate = updateLogs[0];
+      } else {
+        throw new Error('multiple home updates for same root');
+      }
     }
     // return the event or undefined if it doesn't exist
     return this.cache.homeUpdate;
@@ -280,11 +284,16 @@ export class NomadMessage {
       UpdateTypes,
       UpdateArgs
     >(this.context, this.destination, this.replica, updateFilter);
-    if (updateLogs.length === 1) {
-      // if event is returned, store it to the object
-      this.cache.replicaUpdate = updateLogs[0];
-    } else if (updateLogs.length > 1) {
-      throw new Error('multiple replica updates for same root');
+
+    if (updateLogs.length > 0) {
+      // check for distinct (fraudulent) updates
+      const validUpdates = updateLogs.every(u => u === updateLogs[0]);
+      if (validUpdates) {
+        // if event is returned and valid, store it to the object
+        this.cache.replicaUpdate = updateLogs[0];
+      } else {
+        throw new Error('multiple home updates for same root');
+      }
     }
     // return the event or undefined if it wasn't found
     return this.cache.replicaUpdate;


### PR DESCRIPTION
We've seen this a handful of times now where there are multiple identical updates and the sdk falsely reports a double update.

This checks for distinct updates in the array.