### PR TITLE
fix: separate gas estimate and price policies and check for reverts in TxReceipts in processor

### DIFF
--- a/rust/agents/processor/src/processor.rs
+++ b/rust/agents/processor/src/processor.rs
@@ -275,7 +275,10 @@ impl Replica {
 
         if let Some(tx_outcome) = possible_tx_outcome {
             if !tx_outcome.executed {
-                bail!("Process transaction {:?} was reverted", tx_outcome.txid);
+                return Err(ProcessorError::ProcessTransactionReverted {
+                    tx: tx_outcome.txid,
+                }
+                .into());
             }
         }
 

--- a/rust/agents/processor/src/processor.rs
+++ b/rust/agents/processor/src/processor.rs
@@ -252,7 +252,7 @@ impl Replica {
         use nomad_core::Replica;
         let status = self.replica.message_status(message.to_leaf()).await?;
 
-        let possible_tx_outcome = match status {
+        let opt_tx_outcome = match status {
             MessageStatus::None => Some(
                 self.replica
                     .prove_and_process(message.as_ref(), &proof)
@@ -273,7 +273,7 @@ impl Replica {
             }
         };
 
-        if let Some(tx_outcome) = possible_tx_outcome {
+        if let Some(tx_outcome) = opt_tx_outcome {
             if !tx_outcome.executed {
                 return Err(ProcessorError::ProcessTransactionReverted {
                     tx: tx_outcome.txid,

--- a/rust/nomad-base/src/error.rs
+++ b/rust/nomad-base/src/error.rs
@@ -58,4 +58,10 @@ pub enum ProcessorError {
         /// Prover leaf
         proof_leaf: H256,
     },
+    /// Processor stored leaf conflicts with the message for the same index
+    #[error("Process transaction {tx:?} was reverted.")]
+    ProcessTransactionReverted {
+        /// Hash of transaction that got reverted
+        tx: H256,
+    },
 }

--- a/rust/nomad-base/src/error.rs
+++ b/rust/nomad-base/src/error.rs
@@ -58,7 +58,7 @@ pub enum ProcessorError {
         /// Prover leaf
         proof_leaf: H256,
     },
-    /// Processor stored leaf conflicts with the message for the same index
+    /// Transaction reverted
     #[error("Process transaction {tx:?} was reverted.")]
     ProcessTransactionReverted {
         /// Hash of transaction that got reverted


### PR DESCRIPTION
- milkomeda running into low gas limit estimate problems (temporarily bumping gas estimate as fix)
- shouldn't cause issues either way since extra unused gas is refunded
- checks for reverts in tx receipts and returns error (crash) if reverted processor
