### PR TITLE
release: bump sdk package version

### DIFF
--- a/typescript/nomad-sdk/package-lock.json
+++ b/typescript/nomad-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nomad-xyz/sdk",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@gnosis.pm/safe-core-sdk": "^1.3.0",

--- a/typescript/nomad-sdk/package.json
+++ b/typescript/nomad-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomad-xyz/sdk",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Nomad SDK",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Already published (https://www.npmjs.com/package/@nomad-xyz/sdk/v/1.3.7)