### PR TITLE
feature: deploy custom tokens (if configured)

### DIFF
--- a/typescript/nomad-deploy/src/bridge/BridgeContracts.ts
+++ b/typescript/nomad-deploy/src/bridge/BridgeContracts.ts
@@ -6,11 +6,19 @@ import * as contracts from '@nomad-xyz/contract-interfaces/core';
 
 type SignerOrProvider = ethers.ethers.providers.Provider | ethers.ethers.Signer;
 
+export interface DeployedCustomToken {
+  id: string;
+  domain: number;
+  controller: string;
+  addresses: ProxyAddresses;
+}
+
 export type BridgeContractAddresses = {
   bridgeRouter: ProxyAddresses;
   tokenRegistry: ProxyAddresses;
   bridgeToken: ProxyAddresses;
   ethHelper?: string;
+  customs?: Array<DeployedCustomToken>;
 };
 
 export class BridgeContracts extends Contracts {
@@ -18,6 +26,7 @@ export class BridgeContracts extends Contracts {
   tokenRegistry?: BeaconProxy<xAppContracts.TokenRegistry>;
   bridgeToken?: BeaconProxy<xAppContracts.BridgeToken>;
   ethHelper?: xAppContracts.ETHHelper;
+  customs?: Array<DeployedCustomToken>;
 
   constructor() {
     super();
@@ -29,6 +38,7 @@ export class BridgeContracts extends Contracts {
       tokenRegistry: this.tokenRegistry?.toObject(),
       bridgeToken: this.bridgeToken?.toObject(),
       ethHelper: this.ethHelper?.address,
+      customs: this.customs,
     };
   }
 
@@ -37,6 +47,8 @@ export class BridgeContracts extends Contracts {
     signerOrProvider: SignerOrProvider,
   ): BridgeContracts {
     const b = new BridgeContracts();
+
+    b.customs = addresses.customs;
 
     // TODO: needs type magic for turning governance, home and replicas to BeaconProxy contracts
     const routerImplementation = xAppContracts.BridgeRouter__factory.connect(

--- a/typescript/nomad-deploy/src/bridge/BridgeContracts.ts
+++ b/typescript/nomad-deploy/src/bridge/BridgeContracts.ts
@@ -9,6 +9,9 @@ type SignerOrProvider = ethers.ethers.providers.Provider | ethers.ethers.Signer;
 export interface DeployedCustomToken {
   id: string;
   domain: number;
+  name: string;
+  symbol: string;
+  decimals: number;
   controller: string;
   addresses: ProxyAddresses;
 }

--- a/typescript/nomad-deploy/src/bridge/BridgeDeploy.ts
+++ b/typescript/nomad-deploy/src/bridge/BridgeDeploy.ts
@@ -7,9 +7,17 @@ import {
 import { Deploy } from '../deploy';
 import { ethers } from 'ethers';
 
+export type CustomTokenSpecifier = {
+  id: string;
+  domain: number;
+  name: string;
+  symbol: string;
+  decimals: number;
+};
+
 export type BridgeConfig = {
   weth?: string;
-  customs?: ReadonlyArray<{ id: string; domain: number }>;
+  customs?: ReadonlyArray<CustomTokenSpecifier>;
 };
 
 export class BridgeDeploy extends Deploy<BridgeContracts> {

--- a/typescript/nomad-deploy/src/bridge/BridgeDeploy.ts
+++ b/typescript/nomad-deploy/src/bridge/BridgeDeploy.ts
@@ -9,6 +9,7 @@ import { ethers } from 'ethers';
 
 export type BridgeConfig = {
   weth?: string;
+  customs?: ReadonlyArray<{ id: string; domain: number }>;
 };
 
 export class BridgeDeploy extends Deploy<BridgeContracts> {
@@ -44,8 +45,13 @@ export class BridgeDeploy extends Deploy<BridgeContracts> {
   static freshFromConfig(
     config: ChainJson,
     coreDeployPath: string,
+    bridgeConfig?: BridgeConfig,
   ): BridgeDeploy {
-    return new BridgeDeploy(toChain(config), {}, coreDeployPath);
+    return new BridgeDeploy(
+      toChain(config),
+      bridgeConfig ?? {},
+      coreDeployPath,
+    );
   }
 }
 

--- a/typescript/nomad-deploy/src/bridge/TestBridgeDeploy.ts
+++ b/typescript/nomad-deploy/src/bridge/TestBridgeDeploy.ts
@@ -168,7 +168,7 @@ export default class TestBridgeDeploy {
     return {};
   }
   get config() {
-    return { weth: this.mockWeth.address };
+    return { weth: this.mockWeth.address, customs: [] };
   }
 
   get bridgeRouter(): BridgeRouter | undefined {

--- a/typescript/nomad-deploy/src/bridge/index.ts
+++ b/typescript/nomad-deploy/src/bridge/index.ts
@@ -361,7 +361,7 @@ export async function enrollBridgeRouter(
  *  tokens
  */
 export async function deployCustoms(local: AnyBridgeDeploy): Promise<void> {
-  local.contracts.customs = [];
+  if (!local.contracts.customs) local.contracts.customs = [];
 
   // skip altogether if no customs in the config
   const customs = local.config.customs;

--- a/typescript/nomad-deploy/src/bridge/index.ts
+++ b/typescript/nomad-deploy/src/bridge/index.ts
@@ -418,6 +418,10 @@ export async function deployCustoms(local: AnyBridgeDeploy): Promise<void> {
       proxy.address,
       local.deployer,
     );
+
+    // initialize the token proxy
+    await tokenProxy.initialize(local.overrides);
+
     // set initial details
     await (
       await tokenProxy.setDetails(custom.name, custom.symbol, custom.decimals)

--- a/typescript/nomad-deploy/src/bridge/index.ts
+++ b/typescript/nomad-deploy/src/bridge/index.ts
@@ -440,8 +440,7 @@ export async function deployCustoms(local: AnyBridgeDeploy): Promise<void> {
     await enroll.wait(local.chain.confirmations);
 
     local.contracts.customs.push({
-      id: custom.id,
-      domain: custom.domain,
+      ...custom,
       controller: controller.address,
       addresses: {
         implementation: implementationAddress,

--- a/typescript/nomad-deploy/src/bridge/index.ts
+++ b/typescript/nomad-deploy/src/bridge/index.ts
@@ -460,7 +460,7 @@ export async function deployCustoms(local: AnyBridgeDeploy): Promise<void> {
     ).wait(local.chain.confirmations);
 
     // enroll the custom representation
-    const enroll = await local.contracts.bridgeRouter.proxy.enrollCustom(
+    const enroll = await local.contracts.tokenRegistry!.proxy.enrollCustom(
       custom.domain,
       canonizeId(custom.id),
       proxy.address,

--- a/typescript/nomad-deploy/src/bridge/index.ts
+++ b/typescript/nomad-deploy/src/bridge/index.ts
@@ -414,7 +414,24 @@ export async function deployCustoms(local: AnyBridgeDeploy): Promise<void> {
     );
     await relinquish.wait(local.chain.confirmations);
 
-    const enroll = await local.contracts.bridgeRouter?.proxy.enrollCustom(
+    const tokenProxy = xAppContracts.BridgeToken__factory.connect(
+      proxy.address,
+      local.deployer,
+    );
+    // set initial details
+    await (
+      await tokenProxy.setDetails(custom.name, custom.symbol, custom.decimals)
+    ).wait(local.chain.confirmations);
+
+    // transfer ownership to the bridge router
+    await (
+      await tokenProxy.transferOwnership(
+        local.contracts.bridgeRouter.proxy.address,
+      )
+    ).wait(local.chain.confirmations);
+
+    // enroll the custom representation
+    const enroll = await local.contracts.bridgeRouter.proxy.enrollCustom(
       custom.domain,
       canonizeId(custom.id),
       proxy.address,

--- a/typescript/nomad-deploy/src/bridge/index.ts
+++ b/typescript/nomad-deploy/src/bridge/index.ts
@@ -4,6 +4,8 @@ import {
   checkBridgeConnections,
   checkHubAndSpokeBridgeConnections,
 } from './checks';
+
+import * as coreContracts from '@nomad-xyz/contract-interfaces/core';
 import * as xAppContracts from '@nomad-xyz/contract-interfaces/bridge';
 import fs from 'fs';
 import { BridgeDeploy } from './BridgeDeploy';
@@ -37,6 +39,7 @@ export async function deployBridgesComplete(deploys: AnyBridgeDeploy[]) {
       await deployTokenRegistry(deploy);
       await deployBridgeRouter(deploy);
       await deployEthHelper(deploy);
+      await deployCustoms(deploy);
     }),
   );
 
@@ -348,6 +351,88 @@ export async function enrollBridgeRouter(
   console.log(
     `enrolled ${remote.chain.name} BridgeRouter on ${local.chain.name}`,
   );
+}
+
+/**
+ * Deploy any preconfigured custom tokens. These tokens should be specified by
+ * ID in the configuration block
+ *
+ * @param local - The deploy instance for the chain on which to deploy custom
+ *  tokens
+ */
+export async function deployCustoms(local: AnyBridgeDeploy): Promise<void> {
+  local.contracts.customs = [];
+
+  // skip altogether if no customs in the config
+  const customs = local.config.customs;
+  if (!customs) return;
+
+  // preconditions
+  const implementationAddress =
+    local.contracts.bridgeToken?.implementation.address;
+  if (!implementationAddress)
+    throw new Error('need bridge token implementation');
+  if (!local.contracts.bridgeRouter)
+    throw new Error('need bridge router deployed');
+
+  // factories
+  const ubcFactory = new coreContracts.UpgradeBeaconController__factory(
+    local.deployer,
+  );
+  const beaconFactory = new coreContracts.UpgradeBeacon__factory(
+    local.deployer,
+  );
+  const proxyFactory = new coreContracts.UpgradeBeaconProxy__factory(
+    local.deployer,
+  );
+
+  for (const custom of customs) {
+    // deploy a custom controller
+    const controller = await ubcFactory.deploy(local.overrides);
+    await controller.deployTransaction.wait(local.chain.confirmations);
+
+    // deploy a custom beacon
+    const beacon = await beaconFactory.deploy(
+      implementationAddress,
+      controller.address,
+      local.overrides,
+    );
+    await beacon.deployTransaction.wait(local.chain.confirmations);
+
+    // deploy a proxy
+    const proxy = await proxyFactory.deploy(
+      beacon.address,
+      '0x',
+      local.overrides,
+    );
+    await proxy.deployTransaction.wait(local.chain.confirmations);
+
+    // pre-emptively transfer ownership of controller to governance
+    const relinquish = await controller.transferOwnership(
+      local.coreContractAddresses.governance.proxy,
+      local.overrides,
+    );
+    await relinquish.wait(local.chain.confirmations);
+
+    const enroll = await local.contracts.bridgeRouter?.proxy.enrollCustom(
+      custom.domain,
+      canonizeId(custom.id),
+      proxy.address,
+      local.overrides,
+    );
+    await enroll.wait(local.chain.confirmations);
+
+    local.contracts.customs.push({
+      id: custom.id,
+      domain: custom.domain,
+      controller: controller.address,
+      addresses: {
+        implementation: implementationAddress,
+        proxy: proxy.address,
+        beacon: beacon.address,
+      },
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Adds a deploy-time custom representation feature. This allows us to pre-define custom reprs for migration-less changeover later. To allow maximum flexibility, each representation is deployed with its own UBC and beacon. These reprs are set to delegate to the `BridgeToken` deploy initially.

To use:
- add an array of custom specifiers to the bridge config along weth in the chain configs
- the custom specifier is a domain + an address o 32-byte ID

e.g.
```
{ 
    customs: [
        {domain: 3000, id:"0xabcd.......1234", name: 'My Token', symbol: 'MYTOK', decimals: 8},
    ]
}
```