### PR TITLE
Deploy Replica with Home's current committedRoot

### DIFF
--- a/typescript/nomad-deploy/src/core/index.ts
+++ b/typescript/nomad-deploy/src/core/index.ts
@@ -201,10 +201,13 @@ export async function deployUnenrolledReplica(
     ? contracts.TestReplica__factory
     : contracts.Replica__factory;
 
+  // deploy the new Replica with the remote Home's current committedRoot
+  const currentRoot = await remote.contracts.home?.proxy.committedRoot();
+
   let initData = replica.createInterface().encodeFunctionData('initialize', [
     remote.chain.domain,
     remote.config.updater,
-    ethers.constants.HashZero, // TODO: allow configuration in case of recovery
+    currentRoot,
     remote.config.optimisticSeconds,
   ]);
 

--- a/typescript/nomad-deploy/src/core/index.ts
+++ b/typescript/nomad-deploy/src/core/index.ts
@@ -1,6 +1,5 @@
 import { assert } from 'console';
 import fs from 'fs';
-import { ethers } from 'ethers';
 import * as proxyUtils from '../proxyUtils';
 import { CoreDeploy } from './CoreDeploy';
 import * as contracts from '@nomad-xyz/contract-interfaces/core';

--- a/typescript/nomad-deploy/src/core/index.ts
+++ b/typescript/nomad-deploy/src/core/index.ts
@@ -202,7 +202,10 @@ export async function deployUnenrolledReplica(
 
   // deploy the new Replica with the remote Home's current committedRoot
   const currentRoot = await remote.contracts.home?.proxy.committedRoot();
-
+  if (!currentRoot) {
+    throw new Error(`current root not defined for ${remote.chain.name}`);
+  }
+  
   let initData = replica.createInterface().encodeFunctionData('initialize', [
     remote.chain.domain,
     remote.config.updater,


### PR DESCRIPTION
- deploy Replica contract starting at the remote Home's current committed root 
- without this, Replica will need to "catch up" to the Home, relaying thousands of historical roots to get to the current root