### PR TITLE
fix: nomad monitor queries in chunks when starting from block zero

### DIFF
--- a/typescript/nomad-monitor/package-lock.json
+++ b/typescript/nomad-monitor/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "@nomad-xyz/contract-interfaces": "1.1.1",
-        "@nomad-xyz/sdk": "1.5.0",
+        "@nomad-xyz/sdk": "1.5.1",
         "@types/bunyan": "^1.8.7",
         "@types/express": "^4.17.13",
         "@types/google-spreadsheet": "^3.1.5",
@@ -903,9 +903,9 @@
       "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
     },
     "node_modules/@nomad-xyz/sdk": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@nomad-xyz/sdk/-/sdk-1.5.0.tgz",
-      "integrity": "sha512-4vHdpxp5E2NqpFi2uTLLnJ9T3FTA9Votoj+b5jjsjWf8442yLmNk88umoKLuRuBQxRQuh4WE/77BdDYEM07/mA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@nomad-xyz/sdk/-/sdk-1.5.1.tgz",
+      "integrity": "sha512-Djqjo7xY3Lc6D9KABWbK7JP8kLS1YfleG8XuP5WRkBlFKXwEj0evxGespfclWNK49sE0HONrfqilGKCe5tiCHA==",
       "dependencies": {
         "@gnosis.pm/safe-core-sdk": "^1.3.0",
         "@gnosis.pm/safe-ethers-adapters": "0.1.0-alpha.7",
@@ -8091,9 +8091,9 @@
       }
     },
     "@nomad-xyz/sdk": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@nomad-xyz/sdk/-/sdk-1.5.0.tgz",
-      "integrity": "sha512-4vHdpxp5E2NqpFi2uTLLnJ9T3FTA9Votoj+b5jjsjWf8442yLmNk88umoKLuRuBQxRQuh4WE/77BdDYEM07/mA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@nomad-xyz/sdk/-/sdk-1.5.1.tgz",
+      "integrity": "sha512-Djqjo7xY3Lc6D9KABWbK7JP8kLS1YfleG8XuP5WRkBlFKXwEj0evxGespfclWNK49sE0HONrfqilGKCe5tiCHA==",
       "requires": {
         "@gnosis.pm/safe-core-sdk": "^1.3.0",
         "@gnosis.pm/safe-ethers-adapters": "0.1.0-alpha.7",

--- a/typescript/nomad-monitor/package.json
+++ b/typescript/nomad-monitor/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@nomad-xyz/contract-interfaces": "1.1.1",
-    "@nomad-xyz/sdk": "1.5.0",
+    "@nomad-xyz/sdk": "1.5.1",
     "@types/bunyan": "^1.8.7",
     "@types/express": "^4.17.13",
     "@types/google-spreadsheet": "^3.1.5",

--- a/typescript/nomad-monitor/src/config.ts
+++ b/typescript/nomad-monitor/src/config.ts
@@ -105,7 +105,13 @@ function getNetworks() {
       break;
 
     default:
-      networks = ['rinkeby', 'kovan', 'moonbasealpha', 'milkomedatestnet'];
+      networks = [
+        'rinkeby',
+        'kovan',
+        'moonbasealpha',
+        'milkomedatestnet',
+        'evmostestnet',
+      ];
       break;
   }
 
@@ -124,6 +130,7 @@ export function getRpcsFromEnv() {
     moonbeamRpc: process.env.MOONBEAM_RPC ?? '',
     milkomedac1Rpc: process.env.MILKOMEDAC1_RPC ?? '',
     milkomedatestnetRpc: process.env.MILKOMEDA_TESTNET_RPC ?? '',
+    evmostestnetRpc: process.env.EVMOS_TESTNET_RPC ?? '',
   };
 }
 

--- a/typescript/nomad-monitor/src/config.ts
+++ b/typescript/nomad-monitor/src/config.ts
@@ -26,17 +26,28 @@ export class MonitorConfig {
     const environment = process.env.ENVIRONMENT ?? 'development';
 
     this.origin = origin;
-    this.remotes = getNetworks().filter((m) => m != origin);
     switch (environment) {
       case 'production': {
+        const hub = origin == 'ethereum';
+        this.remotes = hub
+          ? getNetworks().filter((m) => m != origin)
+          : ['ethereum'];
         this.context = contexts.mainnet;
         break;
       }
       case 'staging': {
+        const hub = origin == 'rinkeby';
+        this.remotes = hub
+          ? getNetworks().filter((m) => m != origin)
+          : ['rinkeby'];
         this.context = contexts.staging;
         break;
       }
       default: {
+        const hub = origin == 'rinkeby';
+        this.remotes = hub
+          ? getNetworks().filter((m) => m != origin)
+          : ['rinkeby'];
         this.context = contexts.dev;
         break;
       }
@@ -90,11 +101,11 @@ function getNetworks() {
       break;
 
     case 'staging':
-      networks = ['kovan', 'moonbasealpha'];
+      networks = ['rinkeby', 'kovan', 'moonbasealpha'];
       break;
 
     default:
-      networks = ['kovan', 'moonbasealpha'];
+      networks = ['rinkeby', 'kovan', 'moonbasealpha', 'milkomedatestnet'];
       break;
   }
 
@@ -112,6 +123,7 @@ export function getRpcsFromEnv() {
     moonbasealphaRpc: process.env.MOONBASEALPHA_RPC ?? '',
     moonbeamRpc: process.env.MOONBEAM_RPC ?? '',
     milkomedac1Rpc: process.env.MILKOMEDAC1_RPC ?? '',
+    milkomedatestnetRpc: process.env.MILKOMEDA_TESTNET_RPC ?? '',
   };
 }
 

--- a/typescript/nomad-monitor/src/registerContext.ts
+++ b/typescript/nomad-monitor/src/registerContext.ts
@@ -16,6 +16,7 @@ export function setRpcProviders(rpcs: any) {
   dev.registerRpcProvider('kovan', rpcs.kovanRpc);
   dev.registerRpcProvider('moonbasealpha', rpcs.moonbasealphaRpc);
   dev.registerRpcProvider('milkomedatestnet', rpcs.milkomedatestnetRpc);
+  dev.registerRpcProvider('evmostestnet', rpcs.evmostestnetRpc);
 }
 
 export { mainnet, staging, dev };

--- a/typescript/nomad-monitor/src/registerContext.ts
+++ b/typescript/nomad-monitor/src/registerContext.ts
@@ -7,12 +7,15 @@ export function setRpcProviders(rpcs: any) {
   mainnet.registerRpcProvider('milkomedaC1', rpcs.milkomedac1Rpc);
 
   // register staging
+  staging.registerRpcProvider('rinkeby', rpcs.rinkebyRpc);
   staging.registerRpcProvider('moonbasealpha', rpcs.moonbasealphaRpc);
   staging.registerRpcProvider('kovan', rpcs.kovanRpc);
 
   // register dev
+  dev.registerRpcProvider('rinkeby', rpcs.rinkebyRpc);
   dev.registerRpcProvider('kovan', rpcs.kovanRpc);
   dev.registerRpcProvider('moonbasealpha', rpcs.moonbasealphaRpc);
+  dev.registerRpcProvider('milkomedatestnet', rpcs.milkomedatestnetRpc);
 }
 
 export { mainnet, staging, dev };

--- a/typescript/nomad-monitor/src/run.ts
+++ b/typescript/nomad-monitor/src/run.ts
@@ -3,6 +3,7 @@ import { RelayLatencyMonitor } from './latencies/relayer/relayerMonitor';
 import { ProcessorLatencyMonitor } from './latencies/processor/processorMonitor';
 import { BridgeHealthMonitor } from './bridgeHealth/healthMonitor';
 import { E2ELatencyMonitor } from './latencies/e2e/e2eMonitor';
+import { FromBlock } from './monitorSingle';
 
 export enum Script {
   Health = 'health',
@@ -19,16 +20,18 @@ const origin = args[1];
   const config = new MonitorConfig(script, origin);
   switch (script) {
     case Script.Health:
-      await new BridgeHealthMonitor(config).main();
+      await new BridgeHealthMonitor(config).main(FromBlock.Zero);
       break;
     case Script.E2E:
-      await new E2ELatencyMonitor(config).main();
+      await new E2ELatencyMonitor(config).main(FromBlock.ThousandBehindTip);
       break;
     case Script.Relayer:
-      await new RelayLatencyMonitor(config).main();
+      await new RelayLatencyMonitor(config).main(FromBlock.ThousandBehindTip);
       break;
     case Script.Processor:
-      await new ProcessorLatencyMonitor(config).main();
+      await new ProcessorLatencyMonitor(config).main(
+        FromBlock.ThousandBehindTip,
+      );
       break;
     default:
       throw new Error(`Undefined script found: ${script}`);


### PR DESCRIPTION
- moonbeam RPC requests from block 0...tip are timing out, breaking health monitor
- PR adds `largeQueryInChunks` to mitigate issue and query in 2000 block chunks