### PR TITLE
fix: always start monitor tools 200k blocks behind tip to avoid initial indexing rate limit

### DIFF
--- a/typescript/nomad-monitor/src/config.ts
+++ b/typescript/nomad-monitor/src/config.ts
@@ -129,8 +129,8 @@ export function getRpcsFromEnv() {
     moonbasealphaRpc: process.env.MOONBASEALPHA_RPC ?? '',
     moonbeamRpc: process.env.MOONBEAM_RPC ?? '',
     milkomedac1Rpc: process.env.MILKOMEDAC1_RPC ?? '',
-    milkomedatestnetRpc: process.env.MILKOMEDA_TESTNET_RPC ?? '',
-    evmostestnetRpc: process.env.EVMOS_TESTNET_RPC ?? '',
+    milkomedatestnetRpc: process.env.MILKOMEDATESTNET_RPC ?? '',
+    evmostestnetRpc: process.env.EVMOSTESTNET_RPC ?? '',
   };
 }
 

--- a/typescript/nomad-monitor/src/monitorSingle.ts
+++ b/typescript/nomad-monitor/src/monitorSingle.ts
@@ -76,7 +76,10 @@ export abstract class MonitorSingle {
       const remoteProvider = this.networkToProvider(remote);
       const latestRemoteBlock = await remoteProvider.getBlockNumber();
       Object.values(EventType).forEach((eventType) => {
-        this.lastSeenBlocks.set(remote + eventType, latestRemoteBlock - 1000);
+        this.lastSeenBlocks.set(
+          remote + eventType,
+          latestRemoteBlock - blocksBehindTip,
+        );
       });
     });
   }
@@ -138,6 +141,10 @@ export abstract class MonitorSingle {
       network == this.origin ? this.home : this.replicas.get(network)!;
     const filter = this.getFilter(network, eventType);
 
+    this.logInfo(
+      `Starting in large fetch for blocks ${from}..${to} for ${network}.`,
+    );
+
     while (from < to) {
       let finalTo = Math.min(from + chunkSize, to);
       try {
@@ -163,6 +170,9 @@ export abstract class MonitorSingle {
       }
     }
 
+    this.logInfo(
+      `Finished large fetch for blocks ${from}..${to} for ${network}.`,
+    );
     return events;
   }
 
@@ -202,12 +212,11 @@ export abstract class MonitorSingle {
         );
 
         let events;
-        if (from == undefined) {
-          this.logInfo('Fetching in large chunks...');
+        if (from == undefined || latestBlock - from >= 10_000) {
           events = this.largeQueryInChunks(
             network,
             eventType,
-            0,
+            from ?? 0,
             latestBlock,
             2000,
           );

--- a/typescript/nomad-monitor/src/monitorSingle.ts
+++ b/typescript/nomad-monitor/src/monitorSingle.ts
@@ -26,11 +26,6 @@ export enum IndexType {
   FromZero,
 }
 
-export enum FromBlock {
-  Zero,
-  ThousandBehindTip,
-}
-
 export abstract class MonitorSingle {
   origin: string;
   remotes: string[];
@@ -61,19 +56,19 @@ export abstract class MonitorSingle {
 
   abstract start(): Promise<void>;
 
-  public async main(fromBlock: FromBlock) {
+  public async main(blocksBehindTip: number) {
     this.metrics.startServer(9090);
-    if (fromBlock != FromBlock.Zero) await this.initializeStartBlocks();
+    await this.initializeStartBlocks(blocksBehindTip);
     await this.start();
   }
 
-  private async initializeStartBlocks() {
+  private async initializeStartBlocks(blocksBehindTip: number) {
     const originProvider = this.networkToProvider(this.origin);
     const latestOriginBlock = await originProvider.getBlockNumber();
     Object.values(EventType).forEach((eventType) => {
       this.lastSeenBlocks.set(
         this.origin + eventType,
-        latestOriginBlock - 1000,
+        latestOriginBlock - blocksBehindTip,
       );
     });
 

--- a/typescript/nomad-monitor/src/run.ts
+++ b/typescript/nomad-monitor/src/run.ts
@@ -3,7 +3,6 @@ import { RelayLatencyMonitor } from './latencies/relayer/relayerMonitor';
 import { ProcessorLatencyMonitor } from './latencies/processor/processorMonitor';
 import { BridgeHealthMonitor } from './bridgeHealth/healthMonitor';
 import { E2ELatencyMonitor } from './latencies/e2e/e2eMonitor';
-import { FromBlock } from './monitorSingle';
 
 export enum Script {
   Health = 'health',
@@ -20,18 +19,16 @@ const origin = args[1];
   const config = new MonitorConfig(script, origin);
   switch (script) {
     case Script.Health:
-      await new BridgeHealthMonitor(config).main(FromBlock.Zero);
+      await new BridgeHealthMonitor(config).main(200_000);
       break;
     case Script.E2E:
-      await new E2ELatencyMonitor(config).main(FromBlock.ThousandBehindTip);
+      await new E2ELatencyMonitor(config).main(200_000);
       break;
     case Script.Relayer:
-      await new RelayLatencyMonitor(config).main(FromBlock.ThousandBehindTip);
+      await new RelayLatencyMonitor(config).main(200_000);
       break;
     case Script.Processor:
-      await new ProcessorLatencyMonitor(config).main(
-        FromBlock.ThousandBehindTip,
-      );
+      await new ProcessorLatencyMonitor(config).main(200_000);
       break;
     default:
       throw new Error(`Undefined script found: ${script}`);


### PR DESCRIPTION
- monitor tools don't need all data starting from block 0
- health monitor now only starts looking for data 200k blocks behind tip which is a little over 24 hours worth of blocks for a 1 sec block time
- want to avoid adding per network start blocks due (too many variables to update for every new deploy or redeploy)